### PR TITLE
Implement hierarchical chapter writer with tests

### DIFF
--- a/core/output/hierarchical_writer.py
+++ b/core/output/hierarchical_writer.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from ..adapters.document_parser import parse_document
+from ..render.markdown_renderer import render_markdown
+from .writer import Writer
+
+_HEADING_RE = re.compile(r"^(\d+(?:\.\d+)*)\s+(.+)$")
+_HEADING_RE_DOT = re.compile(r"^(\d+(?:\.\d+)*)\.\s+(.+)$")
+_HEADING_RE_DASH = re.compile(r"^(\d+(?:\.\d+)*)\s*[-–—]\s*(.+)$")
+
+
+def _split_number_and_title(text: str) -> Tuple[List[int], str]:
+    """Splits heading text into numbering and title."""
+    s = text.strip()
+    for rx in (_HEADING_RE_DOT, _HEADING_RE_DASH, _HEADING_RE):
+        m = rx.match(s)
+        if m:
+            nums = [int(x) for x in m.group(1).split(".")]
+            return nums, m.group(2).strip()
+    return [], s
+
+
+def _clean_filename(title: str) -> str:
+    """Removes filesystem reserved characters."""
+    title = re.sub(r"[/\\:*?\"<>|]", " ", title).strip()
+    return re.sub(r"\s{2,}", " ", title)
+
+
+def _code_for_levels(nums: List[int]) -> str:
+    """Builds a six-digit code based on heading levels."""
+    a = f"{(nums[0] if len(nums) >= 1 else 0):02d}"
+    b = f"{(nums[1] if len(nums) >= 2 else 0):02d}"
+    c = f"{(nums[2] if len(nums) >= 3 else 0):02d}"
+    return f"{a}{b}{c}"
+
+
+@dataclass
+class _Section:
+    level: int
+    number: List[int]
+    title: str
+    blocks: list
+
+
+def _collect_sections(blocks: list) -> List[_Section]:
+    """Breaks blocks into hierarchical sections."""
+    sections: List[_Section] = []
+    cur_h1: Optional[_Section] = None
+    cur_h2_intro: Optional[_Section] = None
+    cur_h3: Optional[_Section] = None
+
+    def flush_h3() -> None:
+        nonlocal cur_h3
+        if cur_h3 and cur_h3.blocks:
+            sections.append(cur_h3)
+        cur_h3 = None
+
+    def flush_h2() -> None:
+        nonlocal cur_h2_intro
+        if cur_h2_intro and cur_h2_intro.blocks:
+            sections.append(cur_h2_intro)
+        cur_h2_intro = None
+
+    for blk in blocks:
+        if getattr(blk, "type", None) == "heading":
+            text = blk.text or ""
+            lvl = blk.level
+            nums, ttl = _split_number_and_title(text)
+            if lvl == 1 and nums:
+                flush_h3()
+                flush_h2()
+                cur_h1 = _Section(1, [nums[0]], ttl, [blk])
+                sections.append(cur_h1)
+                continue
+            if lvl == 2 and nums and cur_h1:
+                flush_h3()
+                flush_h2()
+                cur_h2_intro = _Section(2, [nums[0], nums[1]], ttl, [blk])
+                continue
+            if lvl == 3 and nums and cur_h1:
+                flush_h3()
+                if cur_h2_intro:
+                    sections.append(cur_h2_intro)
+                    cur_h2_intro = None
+                cur_h3 = _Section(3, [nums[0], nums[1], nums[2]], ttl, [blk])
+                continue
+            target = cur_h3 or cur_h2_intro or cur_h1
+            if target:
+                target.blocks.append(blk)
+            continue
+        target = cur_h3 or cur_h2_intro or cur_h1
+        if target:
+            target.blocks.append(blk)
+
+    flush_h3()
+    flush_h2()
+    return sections
+
+
+def export_docx_hierarchy(docx_path: str | os.PathLike, out_root: str | os.PathLike) -> List[Path]:
+    """Exports a DOCX into a folder hierarchy by headings."""
+    writer = Writer()
+    out_root = Path(out_root)
+    out_root.mkdir(parents=True, exist_ok=True)
+    doc, _ = parse_document(str(docx_path))
+    sections = _collect_sections(doc.blocks)
+    written: List[Path] = []
+    h1_dir: Optional[Path] = None
+    last_h1_num: Optional[int] = None
+    for sec in sections:
+        code = _code_for_levels(sec.number)
+        safe_title = _clean_filename(sec.title)
+        if sec.level == 1:
+            last_h1_num = sec.number[0]
+            h1_dir = out_root / f"{code}.{safe_title}"
+            writer.ensure_dir(h1_dir)
+            writer.ensure_dir(h1_dir / "images")
+            md = render_markdown(type("Doc", (), {"blocks": sec.blocks}), asset_map={})
+            path = h1_dir / "index.md"
+            writer.write_text(path, md)
+            written.append(path)
+        elif sec.level == 2:
+            assert h1_dir is not None and last_h1_num == sec.number[0]
+            md = render_markdown(type("Doc", (), {"blocks": sec.blocks}), asset_map={})
+            path = h1_dir / f"{code}.{safe_title}.md"
+            writer.write_text(path, md)
+            written.append(path)
+        elif sec.level == 3:
+            assert h1_dir is not None and last_h1_num == sec.number[0]
+            md = render_markdown(type("Doc", (), {"blocks": sec.blocks}), asset_map={})
+            path = h1_dir / f"{code}.{safe_title}.md"
+            writer.write_text(path, md)
+            written.append(path)
+        else:
+            md = render_markdown(type("Doc", (), {"blocks": sec.blocks}), asset_map={})
+            fallback_code = _code_for_levels(sec.number[:3])
+            if h1_dir:
+                path = h1_dir / f"{fallback_code}.{safe_title}.md"
+            else:
+                path = out_root / f"{fallback_code}.{safe_title}.md"
+            writer.write_text(path, md)
+            written.append(path)
+    return written

--- a/tests/output/test_hierarchical_writer.py
+++ b/tests/output/test_hierarchical_writer.py
@@ -1,0 +1,90 @@
+from pathlib import Path
+
+import pytest
+
+from core.model.internal_doc import InternalDoc, Heading, Paragraph, Text
+
+# Import functions to be tested
+from core.output.hierarchical_writer import (
+    _split_number_and_title,
+    _code_for_levels,
+    _collect_sections,
+    export_docx_hierarchy,
+)
+
+
+def test_split_number_and_title_variants():
+    assert _split_number_and_title("1.2.3 Heading") == ([1, 2, 3], "Heading")
+    assert _split_number_and_title("1.2.3. Heading") == ([1, 2, 3], "Heading")
+    assert _split_number_and_title("1.2.3 - Heading") == ([1, 2, 3], "Heading")
+    assert _split_number_and_title("Heading") == ([], "Heading")
+
+
+def test_code_for_levels():
+    assert _code_for_levels([1]) == "010000"
+    assert _code_for_levels([1, 2]) == "010200"
+    assert _code_for_levels([1, 2, 3]) == "010203"
+
+
+def _sample_blocks():
+    return [
+        Heading(level=1, text="1 Chapter 1"),
+        Paragraph(inlines=[Text(content="Intro H1")]),
+        Heading(level=2, text="1.1 Section 1"),
+        Paragraph(inlines=[Text(content="Intro Section")]),
+        Heading(level=3, text="1.1.1 Topic A"),
+        Paragraph(inlines=[Text(content="Content A")]),
+        Heading(level=3, text="1.1.2 Topic B"),
+        Paragraph(inlines=[Text(content="Content B")]),
+        Heading(level=2, text="1.2 Section 2"),
+        Paragraph(inlines=[Text(content="Section 2 content")]),
+        Heading(level=1, text="2 Chapter 2"),
+        Paragraph(inlines=[Text(content="Chapter 2 intro")]),
+    ]
+
+
+def test_collect_sections_splits_blocks_correctly():
+    sections = _collect_sections(_sample_blocks())
+    titles = [s.title for s in sections]
+    assert titles == [
+        "Chapter 1",
+        "Section 1",
+        "Topic A",
+        "Topic B",
+        "Section 2",
+        "Chapter 2",
+    ]
+    numbers = [s.number for s in sections]
+    assert numbers == [
+        [1],
+        [1, 1],
+        [1, 1, 1],
+        [1, 1, 2],
+        [1, 2],
+        [2],
+    ]
+    for sec in sections:
+        heading = sec.blocks[0]
+        assert isinstance(heading, Heading)
+        assert heading.text.startswith(".".join(map(str, sec.number)))
+
+
+def test_export_docx_hierarchy_creates_structure(tmp_path, monkeypatch):
+    doc = InternalDoc(blocks=_sample_blocks())
+    monkeypatch.setattr(
+        "core.output.hierarchical_writer.parse_document", lambda path: (doc, {})
+    )
+    written = export_docx_hierarchy("dummy.docx", tmp_path)
+    expected = {
+        tmp_path / "010000.Chapter 1" / "index.md",
+        tmp_path / "010000.Chapter 1" / "010100.Section 1.md",
+        tmp_path / "010000.Chapter 1" / "010101.Topic A.md",
+        tmp_path / "010000.Chapter 1" / "010102.Topic B.md",
+        tmp_path / "010000.Chapter 1" / "010200.Section 2.md",
+        tmp_path / "020000.Chapter 2" / "index.md",
+    }
+    assert set(written) == expected
+    index_content = Path(tmp_path / "010000.Chapter 1" / "index.md").read_text()
+    assert index_content.startswith("# 1 Chapter 1")
+    h3_content = Path(tmp_path / "010000.Chapter 1" / "010101.Topic A.md").read_text()
+    assert h3_content.startswith("### 1.1.1 Topic A")


### PR DESCRIPTION
## Summary
- add hierarchical_writer to export DOCX chapters into structured directories
- support heading number parsing and level code generation
- cover chapter splitting and exporting logic with unit tests

## Testing
- `.venv/bin/pytest tests/output/test_hierarchical_writer.py`
- `.venv/bin/pytest` *(fails: FileNotFoundError: no such file or directory '/home/spec/work/rosa/docling/docx-s/cu-admin-install.docx')*

------
https://chatgpt.com/codex/tasks/task_e_68c2c5b0b484832ba784f9ae1d2f7742