### PR TITLE
Replace section references with titles

### DIFF
--- a/tests/test_cross_references.py
+++ b/tests/test_cross_references.py
@@ -1,0 +1,33 @@
+"""Tests for replacing cross references with section titles."""
+from core.adapters.document_parser import parse_document
+from core.model.internal_doc import Paragraph
+
+
+def _paragraph_text(paragraph: Paragraph) -> str:
+    return "".join(getattr(inline, "content", "") for inline in paragraph.inlines)
+
+
+def test_cross_references_replaced_with_section_titles() -> None:
+    doc, _ = parse_document("real-docs/hrom-12-admin-foundations.docx")
+    paragraphs = [
+        _paragraph_text(block)
+        for block in doc.blocks
+        if isinstance(block, Paragraph)
+    ]
+
+    flows_reference = next(
+        text
+        for text in paragraphs
+        if text.startswith("Более подробный разбор потоков")
+    )
+    gzip_reference = next(
+        text
+        for text in paragraphs
+        if text.startswith("Опции утилиты bzip2 аналогичны опциям Gzip")
+    )
+
+    assert "п.14.2" not in flows_reference
+    assert "п. Жизненный цикл процесса" in flows_reference
+
+    assert "п.21.1" not in gzip_reference
+    assert "п. Утилита Gzip" in gzip_reference


### PR DESCRIPTION
## Summary
- replace numeric cross references in DOCX paragraphs with the corresponding section titles
- add a regression test covering the hrom-12 admin foundations document references

## Testing
- .venv/bin/pytest tests/test_cross_references.py
- .venv/bin/pytest *(fails: test_current_table_parsing.py expects a document at /home/spec/work/rosa/marker/real-docs/hrom-12-admin-foundations.docx)*

------
https://chatgpt.com/codex/tasks/task_e_68ca973e954c832b8a9040e7805c50e5