### PR TITLE
Format table action cells with image lists

### DIFF
--- a/core/render/markdown_renderer.py
+++ b/core/render/markdown_renderer.py
@@ -182,20 +182,82 @@ def _render_block(
         fence = " ".join(info)
         return f"```{fence}\n{block.code}\n```"
     if type == "table":
+        def _render_image_action_list(cell) -> str | None:
+            blocks = list(cell.blocks)
+            if not blocks:
+                return None
+            images = []
+            index = 0
+            for block in blocks:
+                if getattr(block, "type", None) != "image":
+                    break
+                rendered_image = _render_block(
+                    block,
+                    asset_map,
+                    document_name,
+                    parent_stack + ("table",),
+                )
+                if rendered_image.startswith("::sign-image"):
+                    return None
+                images.append(block)
+                index += 1
+            if not images:
+                return None
+            tail_blocks = blocks[index:]
+            if len(tail_blocks) != 1:
+                return None
+            last_block = tail_blocks[0]
+            if getattr(last_block, "type", None) != "paragraph":
+                return None
+            paragraph_text = "".join(
+                _render_inline_for_table(inline) for inline in last_block.inlines
+            )
+            parts = re.split(r"(?:(?<=^)|(?<=\s))[–—]\s*", paragraph_text)
+            if len(parts) <= 1:
+                return None
+            if parts[0].strip():
+                return None
+            descriptions = [segment.strip() for segment in parts[1:] if segment.strip()]
+            if len(descriptions) != len(images):
+                return None
+            list_items: List[str] = []
+            for image, description in zip(images, descriptions):
+                caption = _escape_table_content(_image_sign_text(image))
+                item = f"- [{caption}](/{image.resource_id}.png)"
+                if description:
+                    item = f"{item} {description}"
+                list_items.append(item)
+            return "\n".join(list_items)
+
+        def _render_cell(cell) -> str:
+            special = _render_image_action_list(cell)
+            if special is not None:
+                return special
+            cell_parts = [
+                _render_block_for_table(
+                    b,
+                    asset_map,
+                    document_name,
+                    parent_stack,
+                )
+                for b in cell.blocks
+            ]
+            return " ".join(cell_parts).strip()
+
         def _row(r) -> str:
-            cells = []
-            for cell in r.cells:
-                cell_parts = [
-                    _render_block_for_table(
-                        b,
-                        asset_map,
-                        document_name,
-                        parent_stack,
-                    )
-                    for b in cell.blocks
+            rendered_cells = [_render_cell(cell) for cell in r.cells]
+            if any("\n" in cell for cell in rendered_cells):
+                split_cells = [cell.splitlines() for cell in rendered_cells]
+                max_lines = max(len(lines) for lines in split_cells)
+                padded_cells: List[List[str]] = [
+                    lines + [""] * (max_lines - len(lines)) for lines in split_cells
                 ]
-                cells.append(" ".join(cell_parts).strip())
-            return "| " + " | ".join(cells) + " |"
+                assembled_lines = []
+                for line_index in range(max_lines):
+                    line_cells = [cells[line_index] for cells in padded_cells]
+                    assembled_lines.append("| " + " | ".join(line_cells) + " |")
+                return "\n".join(assembled_lines)
+            return "| " + " | ".join(rendered_cells) + " |"
 
         header = _row(block.header)
         sep = "| " + " | ".join(["---"] * len(block.header.cells)) + " |"

--- a/tests/test_table_image_rendering.py
+++ b/tests/test_table_image_rendering.py
@@ -124,6 +124,46 @@ class TestTableImageRendering:
         assert "[Кнопка \\| с символом \\|](/special_image.png)" in result
         assert "::sign-image" not in result
 
+    def test_action_cell_renders_image_list(self):
+        """Cells with multiple images followed by dash descriptions render as lists."""
+        image_one = Image(
+            type="image",
+            resource_id="action_edit",
+            alt="Icon edit",
+            caption="Рисунок 64",
+        )
+        image_two = Image(
+            type="image",
+            resource_id="action_widget",
+            alt="Icon widget",
+            caption="Рисунок 181",
+        )
+        action_paragraph = Paragraph(
+            inlines=[
+                Text(content="– Переключиться в режим редактирования панели."),
+                Text(content=" – Режим редактирования также открывается при создании новой панели."),
+            ]
+        )
+        action_cell = TableCell(blocks=[image_one, image_two, action_paragraph])
+        header = TableRow(
+            cells=[TableCell(blocks=[Paragraph(inlines=[Text(content="Действия")])])]
+        )
+        row = TableRow(cells=[action_cell])
+        table = Table(header=header, rows=[row])
+        doc = InternalDoc(blocks=[table])
+
+        asset_map = {
+            "action_edit": "/assets/action_edit.png",
+            "action_widget": "/assets/action_widget.png",
+        }
+
+        result = render_markdown(doc, asset_map)
+
+        list_lines = [line for line in result.splitlines() if line.startswith("| - [")]
+        assert len(list_lines) == 2
+        assert "- [Рисунок 64](/action_edit.png) Переключиться в режим редактирования панели." in list_lines[0]
+        assert "- [Рисунок 181](/action_widget.png) Режим редактирования также открывается при создании новой панели." in list_lines[1]
+
     def test_image_in_list_item_uses_link_format(self):
         """Images inside list items should render as links."""
         image_block = Image(


### PR DESCRIPTION
## Summary
- detect table cells that begin with image blocks followed by en-dash descriptions and render them as markdown lists with links
- keep ::sign-image resources untouched and support multi-line table rows when list formatting is applied
- cover the new behavior with a regression test for action-style table cells

## Testing
- .venv/bin/pytest tests/test_table_image_rendering.py

------
https://chatgpt.com/codex/tasks/task_e_68cd72260f14832b818445428d641956